### PR TITLE
Feature/milc 109224 modify py rit for ci updates

### DIFF
--- a/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
+++ b/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
@@ -92,32 +92,16 @@ def _normalise_evaluator_entry(entry: Any) -> Dict[str, Any]:
     raise ValueError("Evaluator entries must be strings or mappings containing a 'path'")
 
 
-def _collect_evaluator_paths(cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
-    env_multi = os.getenv("PYRIT_EVALUATOR_PATHS")
-    if env_multi:
-        parts = _split_path_list(env_multi)
-        if parts:
-            return [{"path": part} for part in parts]
-        raise ValueError("PYRIT_EVALUATOR_PATHS is set but empty")
+def _collect_evaluator_paths(scorer_raw: Dict[str, Any]) -> List[Dict[str, Any]]:
+    main_normalized = _normalise_evaluator_entry(scorer_raw.get('main'))
+    print('Normalized main scorer entry:', main_normalized)
+    scorer_raw.get('auxiliary')
+    auxiliaries_raw = scorer_raw.get("auxiliary", [])
+    if not isinstance(auxiliaries_raw, list):
+        raise ValueError("evaluator_paths auxiliary entry must be a list")
+    auxiliaries_normalized = [_normalise_evaluator_entry(entry) for entry in auxiliaries_raw]
 
-    env_single = os.getenv("PYRIT_EVALUATOR_PATH")
-    if env_single:
-        return [{"path": env_single}]
-
-    cfg_multi = cfg.get("evaluator_paths")
-    if cfg_multi is not None:
-        if not isinstance(cfg_multi, list):
-            raise ValueError("Config key 'evaluator_paths' must be a list")
-        entries = [_normalise_evaluator_entry(item) for item in cfg_multi]
-        if not entries:
-            raise ValueError("Config key 'evaluator_paths' must contain at least one entry")
-        return entries
-
-    cfg_single = cfg.get("evaluator_path")
-    if cfg_single:
-        return [_normalise_evaluator_entry(cfg_single)]
-
-    return []
+    return [main_normalized] + auxiliaries_normalized
 
 
 def _load_yaml(path: Path) -> Dict[str, Any]:
@@ -193,6 +177,16 @@ def inject_thread_id(raw_http_request: str, thread_id: str, key: str = "threadId
 async def run_async(args: argparse.Namespace) -> int:
     _setup_logging()
 
+    dataset_path_raw = _resolve_required_setting(args.dataset_path, "DATASET_PATH")
+    # Resolve paths with overrides (flag > env > yaml)
+    if not dataset_path_raw:
+        _fail("Config must include dataset_path (or override via flags/env)")
+
+    dataset_path = Path(dataset_path_raw)
+    print('The resolved dataset path is:', dataset_path)
+    if not dataset_path or not dataset_path.exists():
+        _fail(f"Dataset file not found: {dataset_path}")
+
     # Env requirements for HTTP templating
     base_url = _resolve_required_setting(args.target_endpoint, "TARGET_ENDPOINT")
     token = _resolve_required_setting(args.auth_token, "AUTH_TOKEN")
@@ -218,22 +212,23 @@ async def run_async(args: argparse.Namespace) -> int:
     cfg_dir = cfg_path.parent
     cfg = _load_yaml(cfg_path)
 
-    # Resolve paths with overrides (flag > env > yaml)
-    dataset_path = os.getenv("PYRIT_DATASET_PATH") or cfg.get("dataset_path")
-    if not dataset_path:
-        _fail("Config must include dataset_path (or override via flags/env)")
+    scorer_str = _resolve_required_setting(args.scorer, "SCORER")
+    # Parse the JSON string
+    try:
+        scorer_json = json.loads(scorer_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON for --scorer: {e}")
+
 
     try:
-        evaluator_paths = _collect_evaluator_paths(cfg)
+        evaluator_paths = _collect_evaluator_paths(scorer_json)
     except ValueError as exc:
         _fail(str(exc))
 
+    # TODO(FmaDevMode): Continue by also testing if auxiliary scorers are provided correctly.
+    print('Eval paths collected:', evaluator_paths)
     if not evaluator_paths:
         _fail("Config must include evaluator_paths (or override via env)")
-
-    dataset_path_p = _resolve_path(cfg_dir, dataset_path)
-    if not dataset_path_p or not dataset_path_p.exists():
-        _fail(f"Dataset file not found: {dataset_path_p}")
 
     evaluator_entries: List[Dict[str, Any]] = []
     seen_evaluators: Dict[Any, str] = {}
@@ -455,8 +450,7 @@ async def run_async(args: argparse.Namespace) -> int:
             else:
                 raise ValueError(f"Unknown test case format in entry: {entry}")
         return qa_pairs_local
-
-    qa_pairs = _load_test_data(dataset_path_p)
+    qa_pairs = _load_test_data(dataset_path)
 
     # No sharding/max-examples: run all dataset examples
 
@@ -501,7 +495,7 @@ async def run_async(args: argparse.Namespace) -> int:
     report_payload = {
         "report_threshold": report_threshold,
         "execution_time_seconds": elapsed,
-        "dataset_path": str(dataset_path_p) if dataset_path_p else None,
+        "dataset_path": str(dataset_path) if dataset_path else None,
         "output_directory": str(out_dir),
         "report_html": str(out_dir / "dataset_report.html"),
         "scorer_weights": scorer_weight_map,

--- a/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
+++ b/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
@@ -20,7 +20,7 @@ def _setup_logging() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
-def _fail(msg: str) -> None:
+def _fail(msg: str) -> int:
     logging.error(msg)
     sys.exit(2)
 
@@ -100,7 +100,7 @@ def _collect_evaluator_paths(scorer_raw: Dict[str, Any]) -> List[Dict[str, Any]]
     if not isinstance(auxiliaries_raw, list):
         raise ValueError("evaluator_paths auxiliary entry must be a list")
     auxiliaries_normalized = [_normalise_evaluator_entry(entry) for entry in auxiliaries_raw]
-
+    print('Normalized auxiliary scorer entries:', auxiliaries_normalized)
     return [main_normalized] + auxiliaries_normalized
 
 
@@ -180,12 +180,12 @@ async def run_async(args: argparse.Namespace) -> int:
     dataset_path_raw = _resolve_required_setting(args.dataset_path, "DATASET_PATH")
     # Resolve paths with overrides (flag > env > yaml)
     if not dataset_path_raw:
-        _fail("Config must include dataset_path (or override via flags/env)")
+        return _fail("Config must include dataset_path (or override via flags/env)")
 
     dataset_path = Path(dataset_path_raw)
     print('The resolved dataset path is:', dataset_path)
     if not dataset_path or not dataset_path.exists():
-        _fail(f"Dataset file not found: {dataset_path}")
+        return _fail(f"Dataset file not found: {dataset_path}")
 
     # Env requirements for HTTP templating
     base_url = _resolve_required_setting(args.target_endpoint, "TARGET_ENDPOINT")
@@ -208,7 +208,7 @@ async def run_async(args: argparse.Namespace) -> int:
 
     cfg_path = Path(args.config).resolve()
     if not cfg_path.exists():
-        _fail(f"Config not found: {cfg_path}")
+        return _fail(f"Config not found: {cfg_path}")
     cfg_dir = cfg_path.parent
     cfg = _load_yaml(cfg_path)
 
@@ -223,12 +223,10 @@ async def run_async(args: argparse.Namespace) -> int:
     try:
         evaluator_paths = _collect_evaluator_paths(scorer_json)
     except ValueError as exc:
-        _fail(str(exc))
+        return _fail(str(exc))
 
-    # TODO(FmaDevMode): Continue by also testing if auxiliary scorers are provided correctly.
-    print('Eval paths collected:', evaluator_paths)
     if not evaluator_paths:
-        _fail("Config must include evaluator_paths (or override via env)")
+        return _fail("Config must include evaluator_paths (or override via env)")
 
     evaluator_entries: List[Dict[str, Any]] = []
     seen_evaluators: Dict[Any, str] = {}
@@ -236,30 +234,30 @@ async def run_async(args: argparse.Namespace) -> int:
         raw_path = entry.get("path")
         resolved_path = _resolve_path(cfg_dir, raw_path)
         if not resolved_path or not resolved_path.exists():
-            _fail(f"Evaluator file not found: {resolved_path}")
+            return _fail(f"Evaluator file not found: {resolved_path}")
 
         canonical = resolved_path.resolve()
         suffix = canonical.suffix.lower()
         callable_name = entry.get("callable")
         params = entry.get("params") or {}
         if suffix == ".py" and not callable_name:
-            _fail(
+            return _fail(
                 "Programmatic evaluator entries referencing '.py' files must include a 'callable' name"
             )
         if suffix not in (".yaml", ".yml", ".py"):
-            _fail(
+            return _fail(
                 "Evaluator path must end with .yaml/.yml for LLM scorers or .py for programmatic scorers"
             )
         duplicate_key: Any = (canonical, callable_name) if suffix == ".py" else canonical
         if duplicate_key in seen_evaluators:
-            _fail(
+            return _fail(
                 "Duplicate evaluator paths detected: "
                 f"'{raw_path}' resolves to the same location as "
                 f"'{seen_evaluators[duplicate_key]}'"
             )
 
         if suffix == ".py" and params and not isinstance(params, dict):
-            _fail("Evaluator params must be provided as a mapping")
+            return _fail("Evaluator params must be provided as a mapping")
 
         seen_evaluators[duplicate_key] = str(raw_path)
         evaluator_entries.append(
@@ -287,15 +285,15 @@ async def run_async(args: argparse.Namespace) -> int:
     else:
         report_threshold = 0.8
     if not isinstance(field_defs, list):
-        _fail("Config field_defs must be a list")
+        return _fail("Config field_defs must be a list")
     if not http_raw or not thread_id_pattern:
-        _fail("Config must include http_request_raw and thread_id_pattern")
+        return _fail("Config must include http_request_raw and thread_id_pattern")
 
     # Template the raw HTTP request with endpoint + token; preserve {PROMPT}
     try:
         http_request_templated = str(http_raw).format(base_url=base_url, token=token)
     except KeyError as e:
-        _fail(f"http_request_raw templating failed, missing key: {e}")
+        return _fail(f"http_request_raw templating failed, missing key: {e}")
 
     # Initialize PyRIT in-memory DB
     from pyrit.common import initialize_pyrit, IN_MEMORY
@@ -323,7 +321,7 @@ async def run_async(args: argparse.Namespace) -> int:
 
     scorer_type = os.getenv("PYRIT_SCORER_TYPE", "float_scale").strip().lower()
     if scorer_type not in ("float_scale", "true_false"):
-        _fail("PYRIT_SCORER_TYPE must be 'float_scale' or 'true_false'")
+        return _fail("PYRIT_SCORER_TYPE must be 'float_scale' or 'true_false'")
 
     from pyrit.prompt_target import OpenAIChatTarget
     from pyrit.score import Evaluator, Scorer
@@ -340,24 +338,24 @@ async def run_async(args: argparse.Namespace) -> int:
             module_name = f"_pyrit_eval_runner_dynamic_{len(evaluator_specs)}"
             spec = importlib.util.spec_from_file_location(module_name, entry["resolved_path"])
             if spec is None or spec.loader is None:
-                _fail(f"Failed to load programmatic scorer module: {entry['display_path']}")
+                return _fail(f"Failed to load programmatic scorer module: {entry['display_path']}")
             module = importlib.util.module_from_spec(spec)
             try:
                 spec.loader.exec_module(module)
             except Exception as exc:
-                _fail(f"Error importing programmatic scorer '{entry['display_path']}': {exc}")
+                return _fail(f"Error importing programmatic scorer '{entry['display_path']}': {exc}")
 
             try:
                 factory = getattr(module, entry["callable"])
             except AttributeError:
-                _fail(
+                return _fail(
                     "Programmatic evaluator callable '{callable_name}' not found in '{path}'".format(
                         callable_name=entry["callable"], path=entry["display_path"]
                     )
                 )
 
             if not callable(factory):
-                _fail(
+                return _fail(
                     "Programmatic evaluator callable '{callable_name}' in '{path}' is not callable".format(
                         callable_name=entry["callable"], path=entry["display_path"]
                     )
@@ -367,14 +365,14 @@ async def run_async(args: argparse.Namespace) -> int:
             try:
                 scorer_instance = factory(**params)
             except Exception as exc:
-                _fail(
+                return _fail(
                     "Failed to instantiate programmatic evaluator '{callable_name}' from '{path}': {error}".format(
                         callable_name=entry["callable"], path=entry["display_path"], error=exc
                     )
                 )
 
             if not isinstance(scorer_instance, Scorer):
-                _fail(
+                return _fail(
                     "Programmatic evaluator '{callable_name}' in '{path}' must return an instance of pyrit.score.Scorer".format(
                         callable_name=entry["callable"], path=entry["display_path"]
                     )
@@ -463,7 +461,7 @@ async def run_async(args: argparse.Namespace) -> int:
         )
     except (aiohttp.ClientError, asyncio.TimeoutError) as e:
         await session.close()
-        _fail(f"Network error/timeout while contacting target: {e}")
+        return _fail(f"Network error/timeout while contacting target: {e}")
     finally:
         await session.close()
 
@@ -543,8 +541,6 @@ def build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="command", required=True)
 
     run = sub.add_parser("run", help="Run evaluations", description="Run evaluations")
-    # TODO(FmaDevMode): Remove this --command, only needed temporarily to run locally
-    run.add_argument("--command", required=True, help="Temp, should be removed before merge / deploy. If here, please remove this code")
     run.add_argument("--config", required=True, help="Path to Repo-B YAML config")
     run.add_argument("--scorer", required=True, help="The json object defining the main and auxiliary scorer paths")
     run.add_argument("--dataset-path", required=True, help="Path to the dataset YAML file")

--- a/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
+++ b/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
@@ -24,19 +24,6 @@ def _fail(msg: str) -> int:
     logging.error(msg)
     sys.exit(2)
 
-
-def _resolve_required_setting(arg_value: Optional[str], env_name: str) -> str:
-    """Return a required configuration value preferring CLI arg over env."""
-    if arg_value:
-        os.environ[env_name] = arg_value
-        return arg_value
-
-    val = os.getenv(env_name)
-    if not val:
-        _fail(f"Missing configuration for {env_name}")
-    return val
-
-
 def _resolve_optional_setting(
     arg_value: Optional[str], env_name: str, default: Optional[str] = None
 ) -> Optional[str]:
@@ -177,7 +164,7 @@ def inject_thread_id(raw_http_request: str, thread_id: str, key: str = "threadId
 async def run_async(args: argparse.Namespace) -> int:
     _setup_logging()
 
-    dataset_path_raw = _resolve_required_setting(args.dataset_path, "DATASET_PATH")
+    dataset_path_raw = args.dataset_path
     # Resolve paths with overrides (flag > env > yaml)
     if not dataset_path_raw:
         return _fail("Config must include dataset_path (or override via flags/env)")
@@ -188,10 +175,10 @@ async def run_async(args: argparse.Namespace) -> int:
         return _fail(f"Dataset file not found: {dataset_path}")
 
     # Env requirements for HTTP templating
-    base_url = _resolve_required_setting(args.target_endpoint, "TARGET_ENDPOINT")
-    token = _resolve_required_setting(args.auth_token, "AUTH_TOKEN")
+    base_url = args.target_endpoint
+    token = args.auth_token
 
-    api_key = _resolve_required_setting(args.openai_api_key, "OPENAI_API_KEY")
+    api_key = args.openai_api_key
     chat_endpoint = _resolve_optional_setting(
         args.openai_chat_endpoint, "OPENAI_CHAT_ENDPOINT", "https://api.openai.com/v1"
     )
@@ -212,7 +199,7 @@ async def run_async(args: argparse.Namespace) -> int:
     cfg_dir = cfg_path.parent
     cfg = _load_yaml(cfg_path)
 
-    scorer_str = _resolve_required_setting(args.scorer, "SCORER")
+    scorer_str = args.scorer
     # Parse the JSON string
     try:
         scorer_json = json.loads(scorer_str)
@@ -582,3 +569,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         sys.exit(code)
     else:
         parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
+++ b/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
@@ -549,26 +549,35 @@ def build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="command", required=True)
 
     run = sub.add_parser("run", help="Run evaluations", description="Run evaluations")
+    # TODO(FmaDevMode): Remove this --command, only needed temporarily to run locally
+    run.add_argument("--command", required=True, help="Temp, should be removed before merge / deploy. If here, please remove this code")
     run.add_argument("--config", required=True, help="Path to Repo-B YAML config")
-    run.add_argument("--out", default="pyrit_reports", help="Output directory")
+    run.add_argument("--scorer", required=True, help="The json object defining the main and auxiliary scorer paths")
+    run.add_argument("--dataset-path", required=True, help="Path to the dataset YAML file")
+    run.add_argument("--out", required=True, default="pyrit_reports", help="Output directory")
     run.add_argument(
         "--target-endpoint",
+        required=True,
         help="API base URL (overrides TARGET_ENDPOINT)",
     )
     run.add_argument(
         "--auth-token",
+        required=True,
         help="Authentication token (overrides AUTH_TOKEN)",
     )
     run.add_argument(
         "--openai-api-key",
+        required=True,
         help="OpenAI API key (overrides OPENAI_API_KEY)",
     )
     run.add_argument(
         "--openai-chat-endpoint",
+        required=True,
         help="OpenAI chat endpoint (overrides OPENAI_CHAT_ENDPOINT)",
     )
     run.add_argument(
         "--openai-chat-model",
+        required=True,
         help="OpenAI chat model (overrides OPENAI_CHAT_MODEL)",
     )
 

--- a/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
+++ b/pyrit-eval-runner/src/pyrit_eval_runner/cli.py
@@ -82,7 +82,6 @@ def _normalise_evaluator_entry(entry: Any) -> Dict[str, Any]:
 def _collect_evaluator_paths(scorer_raw: Dict[str, Any]) -> List[Dict[str, Any]]:
     main_normalized = _normalise_evaluator_entry(scorer_raw.get('main'))
     print('Normalized main scorer entry:', main_normalized)
-    scorer_raw.get('auxiliary')
     auxiliaries_raw = scorer_raw.get("auxiliary", [])
     if not isinstance(auxiliaries_raw, list):
         raise ValueError("evaluator_paths auxiliary entry must be a list")
@@ -165,7 +164,6 @@ async def run_async(args: argparse.Namespace) -> int:
     _setup_logging()
 
     dataset_path_raw = args.dataset_path
-    # Resolve paths with overrides (flag > env > yaml)
     if not dataset_path_raw:
         return _fail("Config must include dataset_path (or override via flags/env)")
 
@@ -182,16 +180,11 @@ async def run_async(args: argparse.Namespace) -> int:
     chat_endpoint = _resolve_optional_setting(
         args.openai_chat_endpoint, "OPENAI_CHAT_ENDPOINT", "https://api.openai.com/v1"
     )
-    chat_model = _resolve_optional_setting(
-        args.openai_chat_model, "OPENAI_CHAT_MODEL", "gpt-4o-mini"
-    )
 
     if args.openai_api_key or "OPENAI_CHAT_KEY" not in os.environ:
         os.environ["OPENAI_CHAT_KEY"] = api_key
     if chat_endpoint:
         os.environ["OPENAI_CHAT_ENDPOINT"] = chat_endpoint
-    if chat_model:
-        os.environ["OPENAI_CHAT_MODEL"] = chat_model
 
     cfg_path = Path(args.config).resolve()
     if not cfg_path.exists():
@@ -200,7 +193,6 @@ async def run_async(args: argparse.Namespace) -> int:
     cfg = _load_yaml(cfg_path)
 
     scorer_str = args.scorer
-    # Parse the JSON string
     try:
         scorer_json = json.loads(scorer_str)
     except json.JSONDecodeError as e:
@@ -551,11 +543,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--openai-chat-endpoint",
         required=True,
         help="OpenAI chat endpoint (overrides OPENAI_CHAT_ENDPOINT)",
-    )
-    run.add_argument(
-        "--openai-chat-model",
-        required=True,
-        help="OpenAI chat model (overrides OPENAI_CHAT_MODEL)",
     )
 
     return p


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->

This PR aims to improve running our Cli tool, to make it easier to use for our clients. This entails the following changes:
- Extract the dataset and scorer passing from the `config/yaml`, we now explicitely pass these via required runtime args
- Parsing the scorer that is parsed as a json, extracting main scorer info and auxiliary scorer paths
- Resolving the `dataset_path` from the runtime arg
- Residual changes to improve our code quality:
  - Remove the `_resolve_req_setting` function: Not needed as we don't peek into the OS env vars anymore
  - Make `_fail` return an int so we can gracefully return for the compiler
  - Minor var renaming for clarity
  - Remove redundant chat model argument

> [!IMPORTANT]
> This is a breaking change. Afterwards, we can only trigger the eval when explicitely passing the arguments, not from setting env vars into the os and reading them from Python. Why? Because in the old approach we had invisible tight coupling. PyRit was assuming the OS set these values into the env, and the workflow as a result is assuming it should set these values. Both should be agnostic from oneanother, so forcing a requried runtime arg is the preffered approach, as then PyRit visibly enforces the argument.

## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->

For testing you'll have to run this as a module from the root. Please perform these steps:
1. Add the following line to the `build_parser` function: `run.add_argument("--command", required=True, help="Needed as we run it as a module, but will throw during parsing if we don't explicitely accept the --command flag")`
2. Run this in your terminal from the repo root: `export PYTHONPATH="$(pwd)/PyRIT:$(pwd)/pyrit-eval-runner/src"`. It is needed as it tells python to look for modules in both packages, otherwise it has trouble importing PyRit modules
3. Go into `pyrit/datasets/__init__.py` and comment out all imports and references except for` import fetch_many_shot_jailbreaking_dataset` & 
`import TextJailBreak`. The other dataset type evaluations are not needed, and are causing problems as we try to run this as an (incomplete) module
4. Run python -m pyrit_eval_runner.cli run --command run --config ../ah-assistant-service/eval/config.yaml --target-endpoint https://ah-assistant-service-prd.kaas.prd.k8s.ah.technology/sandbox/chat/179168525 --openai-api-key {{ your api key }} --openai-chat-endpoint {{ your ai endpoint }} --out {{ your output path }}  --dataset-path ../ah-assistant-service/eval/datasets/intent-filtering/regression-dataset.yaml --scorer '{"main": {"path": "scorers/steijn-scorer.yaml"}}' --auth-token {{ your acces token }}
5. For step 4 to work, replace all interpolators with actual values, and ensure you have the `ah-assistant-service` repo cloned and in the same folder as this PyRit repo.
